### PR TITLE
Add input update helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ print("mu hat:", comb.fit_results['mu'])
 
 print("68% CI:", comb.confidence_interval())
 print("Goodness of fit:", comb.goodness_of_fit())
+
+# access a dictionary with all input values
+info = comb.input_summary()
+
+# modify the input and update the combination
+info['central']['ATLAS'] = 173.4
+comb.update_inputs(info)
 ```
 
 Only the construction of the likelihood, numerical minimisation and the

--- a/lhc_test.ipynb
+++ b/lhc_test.ipynb
@@ -130,7 +130,22 @@
    "id": "eca91c1f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "info = comb.input_summary()\n",
+    "info['central']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48fbf9cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['central']['a'] += 0.5\n",
+    "comb.update_inputs(info)\n",
+    "comb.fit_results['mu']"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- provide `update_inputs` to modify central values, errors, and systematics
- document updating inputs in README
- add notebook cells showing how to read and edit inputs

## Testing
- `python -m py_compile gvm_toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68765a5c52ec832c8dfe91ffe9a51aa2