### PR TITLE
Add full input editing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ print("mu hat:", comb.fit_results['mu'])
 
 print("68% CI:", comb.confidence_interval())
 print("Goodness of fit:", comb.goodness_of_fit())
+
+# access a dictionary with all input values
+info = comb.input_summary()
+
+# modify the input and update the combination
+info['central']['ATLAS'] = 173.4
+info['systematics']['JES']['ATLAS'] += 0.1
+comb.update_inputs(info)
 ```
 
 Only the construction of the likelihood, numerical minimisation and the

--- a/gvm_toolkit.py
+++ b/gvm_toolkit.py
@@ -32,6 +32,141 @@ class GVMCombination:
         self.fit_results = self.minimize()
 
     # ------------------------------------------------------------------
+    def input_summary(self):
+        """Return dictionaries summarising the combination input.
+
+        The returned dictionary contains the following keys:
+
+        ``central``
+            Mapping measurement name -> central value.
+        ``stat_error``
+            Mapping measurement name -> statistical error.
+        ``stat_corr``
+            Mapping (name1, name2) -> statistical correlation coefficient.
+        ``systematics``
+            Mapping systematic name -> dict of measurement values.
+        ``syst_corr``
+            Mapping systematic name -> dict keyed by ``(name1, name2)`` with
+            correlation coefficients.
+        ``epsilon``
+            Mapping systematic name -> error-on-error.
+        """
+
+        meas = self.measurements
+        n = len(meas)
+
+        if self.stat.ndim == 2:
+            stat_cov = self.stat
+            stat_err = np.sqrt(np.diag(stat_cov))
+        else:
+            stat_err = np.asarray(self.stat)
+            stat_cov = np.diag(stat_err ** 2)
+
+        out = {}
+        out['central'] = dict(zip(meas, self.y))
+        out['stat_error'] = dict(zip(meas, stat_err))
+
+        stat_corr = {}
+        for i in range(n):
+            for j in range(n):
+                denom = stat_err[i] * stat_err[j]
+                rho = stat_cov[i, j] / denom if denom != 0 else 0.0
+                stat_corr[(meas[i], meas[j])] = rho
+        out['stat_corr'] = stat_corr
+
+        syst_value = {}
+        for sname, vals in self.syst.items():
+            syst_value[sname] = {m: vals[i] for i, m in enumerate(meas)}
+        out['systematics'] = syst_value
+
+        syst_corr = {}
+        for sname, rho in self.corr.items():
+            pairs = {}
+            for i in range(n):
+                for j in range(n):
+                    pairs[(meas[i], meas[j])] = float(rho[i, j])
+            syst_corr[sname] = pairs
+        out['syst_corr'] = syst_corr
+
+        epsilon = {k: self.uncertain_systematics.get(k, 0.0)
+                   for k in self.syst.keys()}
+        out['epsilon'] = epsilon
+
+        return out
+
+    # ------------------------------------------------------------------
+    def update_inputs(self, info):
+        """Update combination input from a summary dictionary.
+
+        ``info`` should follow the same structure as returned by
+        :meth:`input_summary`.  Only the provided values are updated.
+        """
+
+        idx = {m: i for i, m in enumerate(self.measurements)}
+
+        if 'central' in info:
+            for m, v in info['central'].items():
+                self.y[idx[m]] = float(v)
+
+        if 'stat_error' in info or 'stat_corr' in info:
+            n = len(self.measurements)
+            errors = {
+                m: (np.sqrt(self.stat[i, i]) if self.stat.ndim == 2 else self.stat[i])
+                for m, i in idx.items()
+            }
+            errors.update(info.get('stat_error', {}))
+            if 'stat_corr' in info:
+                for (a, b), rho in info['stat_corr'].items():
+                    if a == b:
+                        continue
+                    if (b, a) not in info['stat_corr'] or info['stat_corr'][(b, a)] != rho:
+                        raise ValueError('stat_corr must be symmetric')
+                cov = np.zeros((n, n), float)
+                for m in self.measurements:
+                    cov[idx[m], idx[m]] = errors[m] ** 2
+                for (m1, m2), rho in info['stat_corr'].items():
+                    s1 = errors[m1]
+                    s2 = errors[m2]
+                    cov[idx[m1], idx[m2]] = rho * s1 * s2
+                    cov[idx[m2], idx[m1]] = cov[idx[m1], idx[m2]]
+                self.stat = cov
+            else:
+                self.stat = np.array([errors[m] for m in self.measurements], float)
+
+        if 'systematics' in info:
+            for sname, per_meas in info['systematics'].items():
+                if sname not in self.syst:
+                    continue
+                arr = self.syst[sname]
+                for m, val in per_meas.items():
+                    arr[idx[m]] = float(val)
+
+        if 'syst_corr' in info:
+            for sname, corr_map in info['syst_corr'].items():
+                mat = self.corr.get(sname, np.eye(len(self.measurements)))
+                for (a, b), rho in corr_map.items():
+                    if a == b:
+                        continue
+                    if (b, a) not in corr_map or corr_map[(b, a)] != rho:
+                        raise ValueError(f'syst_corr for {sname} must be symmetric')
+                for (m1, m2), rho in corr_map.items():
+                    i, j = idx[m1], idx[m2]
+                    mat[i, j] = mat[j, i] = float(rho)
+                self.corr[sname] = np.asarray(mat, float)
+
+        if 'epsilon' in info:
+            for s, e in info['epsilon'].items():
+                e = float(e)
+                if e == 0:
+                    self.uncertain_systematics.pop(s, None)
+                else:
+                    self.uncertain_systematics[s] = e
+
+        # Recompute matrices and refit after updates
+        self.V_inv, self.C_inv, self.Gamma = self._compute_likelihood_matrices()
+        self.fit_results = self.minimize()
+
+    # ------------------------------------------------------------------
     def _parse_config(self, path):
         cfg = {
             'systematics': {},

--- a/lhc_test.ipynb
+++ b/lhc_test.ipynb
@@ -130,7 +130,110 @@
    "id": "eca91c1f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "info = comb.input_summary()\n",
+    "info['central']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48fbf9cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['central']['a'] += 0.5\n",
+    "comb.update_inputs(info)\n",
+    "comb.fit_results['mu']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff0f1d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['stat_error']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b89580dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['stat_corr'][('a', 'b')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f32a1154",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['systematics']['JER']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78e6cade",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['systematics']['JER']['a']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0d570c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['syst_corr']['JER'][('a', 'b')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19833a76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['epsilon']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e5a60b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comb.corr['JER'][:2, :2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd002432",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info['stat_error']['a'] += 0.1\n",
+    "info['stat_corr'][('a','b')] = 0.1\n",
+    "info['stat_corr'][('b','a')] = 0.1\n",
+    "info['systematics']['JER']['a'] += 0.05\n",
+    "info['syst_corr']['JER'][('a','b')] = 0.3\n",
+    "info['syst_corr']['JER'][('b','a')] = 0.3\n",
+    "info['epsilon']['JER'] = 0.1\n",
+    "comb.update_inputs(info)\n",
+    "comb.fit_results['mu']"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- expand `lhc_test.ipynb` with examples viewing and editing all parts of the combination input
- restructure input maps for systematics
- enforce symmetry when editing correlations

## Testing
- `python -m py_compile gvm_toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68765a5c52ec832c8dfe91ffe9a51aa2