### PR TITLE
Remove stat_cov_dir config

### DIFF
--- a/gvm_toolkit.py
+++ b/gvm_toolkit.py
@@ -51,7 +51,6 @@ class GVMCombination:
         cfg = {}
         glob = data.get('global', data.get('globals', {}))
         corr_dir = glob.get('corr_dir', '')
-        stat_cov_dir = glob.get('stat_cov_dir', '')
         try:
             name = glob['name']
             n_meas = int(glob['n_meas'])
@@ -83,7 +82,6 @@ class GVMCombination:
         stat_cov_path = combo.get('stat_cov_path')
         if stat_cov_path:
             stat_cov_path = stat_cov_path.replace('${global.corr_dir}', corr_dir)
-            stat_cov_path = stat_cov_path.replace('${global.stat_cov_dir}', stat_cov_dir)
             if not os.path.isabs(stat_cov_path):
                 cand = os.path.join(base_dir, stat_cov_path)
                 if os.path.exists(cand):

--- a/input_files/LHC_mass_combination.yaml
+++ b/input_files/LHC_mass_combination.yaml
@@ -5,7 +5,6 @@
 
 global:
   corr_dir:      input_files/correlations/
-  stat_cov_dir:  input_files/statistics/
   n_meas: 15
   n_syst: 25
   name: LHC
@@ -57,7 +56,7 @@ data:
     - label: o
       central: 173.68
       stat_error: 0.20
-  # stat_cov_path: ${global.stat_cov_dir}LHC_stat_cov_15x15.txt
+  # stat_cov_path: ${global.corr_dir}LHC_stat_cov_15x15.txt
 
 syst:
   - name: LHCJES1

--- a/input_files/LHC_mass_combination_cov.yaml
+++ b/input_files/LHC_mass_combination_cov.yaml
@@ -5,7 +5,6 @@
 
 global:
   corr_dir:      input_files/correlations/
-  stat_cov_dir:  input_files/statistics/
   n_meas: 15
   n_syst: 25
   name: LHC


### PR DESCRIPTION
## Summary
- rely on corr_dir path for stat covariance matrix and remove stat_cov_dir
- update YAML examples accordingly

## Testing
- `python -m compileall -q`
- `python - <<'PY'
from gvm_toolkit import GVMCombination
c = GVMCombination('input_files/LHC_mass_combination_cov.yaml')
print('mu', round(c.fit_results['mu'], 3))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6878f6375348832cbbd922bf93a6102c