### PR TITLE
Fix stat_cov_path handling

### DIFF
--- a/gvm_toolkit.py
+++ b/gvm_toolkit.py
@@ -86,6 +86,8 @@ class GVMCombination:
                 cand = os.path.join(base_dir, stat_cov_path)
                 if os.path.exists(cand):
                     stat_cov_path = cand
+                elif corr_dir:
+                    stat_cov_path = os.path.join(corr_dir, stat_cov_path)
             V_stat = np.loadtxt(stat_cov_path, dtype=float)
             if V_stat.shape != (n_meas, n_meas):
                 raise ValueError(f'Stat covariance must be {n_meas}x{n_meas}')

--- a/input_files/LHC_mass_combination_cov.yaml
+++ b/input_files/LHC_mass_combination_cov.yaml
@@ -41,7 +41,7 @@ data:
       central: 173.50
     - label: o
       central: 173.68
-  stat_cov_path: ${global.corr_dir}stat_cov_lhc.txt
+  stat_cov_path: stat_cov_lhc.txt
 
 syst:
   - name: LHCJES1


### PR DESCRIPTION
## Summary
- simplify `stat_cov_path` entry in LHC config
- let `GVMCombination` complete the stat covariance path using `corr_dir`

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from gvm_toolkit import GVMCombination
c = GVMCombination('input_files/LHC_mass_combination_cov.yaml')
print('Shape', c.V_stat.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6878fcfbec18832c93f4a9b0035c7fcf