### PR TITLE
Revise toy tutorial for updated config format

### DIFF
--- a/tutorials/toy/input_files/decorrelated.yaml
+++ b/tutorials/toy/input_files/decorrelated.yaml
@@ -2,7 +2,7 @@ global:
   name: decorrelated
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   measurements:
@@ -11,10 +11,13 @@ data:
       stat_error: 1.0
     - label: m2
       central: -1.5
-      stat_error: 1.
+      stat_error: 1.0
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type: independent
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: diagonal
+    error-on-error:
+      value: 0.0
+      type: independent

--- a/tutorials/toy/input_files/diag_corr.yaml
+++ b/tutorials/toy/input_files/diag_corr.yaml
@@ -2,7 +2,7 @@ global:
   name: diag_corr
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   measurements:
@@ -15,7 +15,9 @@ data:
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type:
-      dependent: diagonal
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: diagonal
+    error-on-error:
+      value: 0.0
+      type: dependent

--- a/tutorials/toy/input_files/full_corr.yaml
+++ b/tutorials/toy/input_files/full_corr.yaml
@@ -2,7 +2,7 @@ global:
   name: full_corr
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   measurements:
@@ -15,7 +15,9 @@ data:
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type:
-      dependent: ones
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: ones
+    error-on-error:
+      value: 0.0
+      type: dependent

--- a/tutorials/toy/input_files/hybrid_corr.yaml
+++ b/tutorials/toy/input_files/hybrid_corr.yaml
@@ -2,7 +2,7 @@ global:
   name: hybrid_corr
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   measurements:
@@ -15,7 +15,9 @@ data:
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type:
-      dependent: hybrid_corr.txt
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: hybrid_corr.txt
+    error-on-error:
+      value: 0.0
+      type: dependent

--- a/tutorials/toy/input_files/stat_cov.yaml
+++ b/tutorials/toy/input_files/stat_cov.yaml
@@ -2,7 +2,7 @@ global:
   name: stat_cov
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   stat_cov_path: stat_cov.txt
@@ -14,7 +14,9 @@ data:
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type:
-      dependent: ones
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: ones
+    error-on-error:
+      value: 0.0
+      type: dependent

--- a/tutorials/toy/tutorial.ipynb
+++ b/tutorials/toy/tutorial.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "In the first part of the tutorial, all error-on-error terms (\\( \\varepsilon \\)) are set to zero, so that only correlations influence the result. In the second part, we show how to introduce and account for errors-on-errors.\n",
     "\n",
-    "For systematic uncertainties without an associated error-on-the-error, the log-likelihood is constructed using the BLUE approach, as described in Sec. 2 of [arXiv:2407.05322](https://arxiv.org/abs/2407.05322). \n"
+    "For systematic uncertainties without an associated error-on-the-error, the log-likelihood is constructed using the BLUE approach, as described in Sec.\u202f2 of [arXiv:2407.05322](https://arxiv.org/abs/2407.05322). \n"
    ]
   },
   {
@@ -72,7 +72,7 @@
      "text": [
       "Decorrelated\n",
       "mu_hat = 0.3462, CI = (-0.5332, 1.2230)\n",
-      "χ² = 2.769, significance = 1.6641005886756863\n"
+      "\u03c7\u00b2 = 2.769, significance = 1.6641005886756863\n"
      ]
     }
    ],
@@ -88,7 +88,7 @@
     "\n",
     "print('Decorrelated')\n",
     "print(f'mu_hat = {mu_hat:.4f}, CI = ({ci_low:.4f}, {ci_high:.4f})')\n",
-    "print(f'χ² = {chi_2:.3f}, significance = {significance}')"
+    "print(f'\u03c7\u00b2 = {chi_2:.3f}, significance = {significance}')"
    ]
   },
   {
@@ -116,15 +116,15 @@
      "text": [
       "Diagonal\n",
       "mu_hat = 0.3462, CI = (-0.5332, 1.2230)\n",
-      "χ² = 2.769, significance = 1.6641005886756863 \n",
+      "\u03c7\u00b2 = 2.769, significance = 1.6641005886756863 \n",
       "\n",
       "Hybrid correlation\n",
       "mu_hat = 0.4500, CI = (-0.5288, 1.4212)\n",
-      "χ² = 3.600, significance = 1.8973665961010266 \n",
+      "\u03c7\u00b2 = 3.600, significance = 1.8973665961010266 \n",
       "\n",
       "Fully correlated\n",
       "mu_hat = 0.5000, CI = (-0.5000, 1.5003)\n",
-      "χ² = 4.000, significance = 1.999999999999998\n"
+      "\u03c7\u00b2 = 4.000, significance = 1.999999999999998\n"
      ]
     }
    ],
@@ -137,9 +137,9 @@
     "significance = norm.ppf(1 - p_value/2)\n",
     "print('Diagonal')\n",
     "print(f'mu_hat = {mu_hat:.4f}, CI = ({ci_low:.4f}, {ci_high:.4f})')\n",
-    "print(f'χ² = {chi_2:.3f}, significance = {significance} \\n')\n",
+    "print(f'\u03c7\u00b2 = {chi_2:.3f}, significance = {significance} \\n')\n",
     "\n",
-    "comb = GVMCombination('correlations/hybrid_corr.yaml')\n",
+    "comb = GVMCombination('input_files/hybrid_corr.yaml')\n",
     "mu_hat = comb.fit_results['mu']\n",
     "ci_low, ci_high, _ = comb.confidence_interval()\n",
     "chi_2 = comb.goodness_of_fit()\n",
@@ -147,9 +147,9 @@
     "significance = norm.ppf(1 - p_value/2)\n",
     "print('Hybrid correlation')\n",
     "print(f'mu_hat = {mu_hat:.4f}, CI = ({ci_low:.4f}, {ci_high:.4f})')\n",
-    "print(f'χ² = {chi_2:.3f}, significance = {significance} \\n')\n",
+    "print(f'\u03c7\u00b2 = {chi_2:.3f}, significance = {significance} \\n')\n",
     "\n",
-    "comb = GVMCombination('correlations/full_corr.yaml')\n",
+    "comb = GVMCombination('input_files/full_corr.yaml')\n",
     "mu_hat = comb.fit_results['mu']\n",
     "ci_low, ci_high, _ = comb.confidence_interval()\n",
     "chi_2 = comb.goodness_of_fit()\n",
@@ -157,7 +157,7 @@
     "significance = norm.ppf(1 - p_value/2)\n",
     "print('Fully correlated')\n",
     "print(f'mu_hat = {mu_hat:.4f}, CI = ({ci_low:.4f}, {ci_high:.4f})')\n",
-    "print(f'χ² = {chi_2:.3f}, significance = {significance}')"
+    "print(f'\u03c7\u00b2 = {chi_2:.3f}, significance = {significance}')\n"
    ]
   },
   {
@@ -168,7 +168,7 @@
     "## 3. Non-diagonal statistical covariance\n",
     "The same systematic is fully correlated as above, but this time the statistical uncertainties are specified via a covariance matrix that includes non-zero off-diagonal terms.\n",
     "\n",
-    "Unlike systematic uncertainties — which can be described through correlation matrices — statistical uncertainties must be provided directly as a **covariance matrix**."
+    "Unlike systematic uncertainties \u2014 which can be described through correlation matrices \u2014 statistical uncertainties must be provided directly as a **covariance matrix**."
    ]
   },
   {
@@ -182,7 +182,7 @@
      "output_type": "stream",
      "text": [
       "mu_hat = 0.5000, CI = (-0.9187, 1.9138)\n",
-      "χ² = 4.000, significance = 1.999999999999998\n"
+      "\u03c7\u00b2 = 4.000, significance = 1.999999999999998\n"
      ]
     }
    ],
@@ -194,7 +194,7 @@
     "p_value = 1 - chi2.cdf(chi_2, df=1)\n",
     "significance = norm.ppf(1 - p_value/2)\n",
     "print(f'mu_hat = {mu_hat:.4f}, CI = ({ci_low:.4f}, {ci_high:.4f})')\n",
-    "print(f'χ² = {chi_2:.3f}, significance = {significance}')\n"
+    "print(f'\u03c7\u00b2 = {chi_2:.3f}, significance = {significance}')\n"
    ]
   },
   {
@@ -229,11 +229,11 @@
     "\n",
     "# change measurement and systematic values\n",
     "info['data']['measurements']['m1']['central'] = 2.0\n",
-    "info['syst']['sys1']['values']['m1'] = 0.5\n",
+    "info['syst']['sys1']['shift']['value']['m1'] = 0.5\n",
     "\n",
     "# update the systematic to be dependent with a new correlation matrix\n",
-    "info['syst']['sys1']['type'] = 'dependent'\n",
-    "info['syst']['sys1']['corr'] = np.array([[1.0, 0.3], [0.3, 1.0]])\n",
+    "info['syst']['sys1']['error-on-error']['type'] = 'dependent'\n",
+    "info['syst']['sys1']['shift']['correlation'] = np.array([[1.0, 0.3], [0.3, 1.0]])\n",
     "\n",
     "# apply modifications and refit\n",
     "comb.update_data(info)\n",
@@ -250,11 +250,11 @@
     "\n",
     "We now vary the error-on-error parameter ($\\varepsilon$) from 0 to 0.6, to show how the combination results depend on its value. When errors-on-errors are different from zero, the distinction between *decorrelated* and *diagonal correlation matrix* becomes clearer.\n",
     "\n",
-    "* When a systematic effect is **decorrelated**, the correlation matrix of the corresponding nuisance parameters is diagonal, and the estimates of the systematic uncertainties for the two measurements are statistically independent. This means that the systematic uncertainty for measurement *m1* could be overestimated while *m2* is underestimated, or vice versa — both estimates can fluctuate independently.\n",
+    "* When a systematic effect is **decorrelated**, the correlation matrix of the corresponding nuisance parameters is diagonal, and the estimates of the systematic uncertainties for the two measurements are statistically independent. This means that the systematic uncertainty for measurement *m1* could be overestimated while *m2* is underestimated, or vice versa \u2014 both estimates can fluctuate independently.\n",
     "\n",
     "* When a systematic effect is **dependent** but described by a **diagonal correlation matrix**, the nuisance parameters are uncorrelated, but the estimates of the systematic uncertainties are dependent. In this case, if one estimate is overestimated, the other must be as well, and vice versa. This situation may arise, for example, when uncorrelated systematic effects are estimated using similar techniques. A typical LHC example is a two-point systematic derived from comparing HERWIG and PYTHIA.\n",
     "\n",
-    "More details on how to implement errors-on-errors in combinations can be found in Sec. 3 of [arXiv:2407.05322](https://arxiv.org/abs/2407.05322), with a more in-depth explanation of dependent vs. independent assumptions in Sec. 3.2."
+    "More details on how to implement errors-on-errors in combinations can be found in Sec.\u00a03 of [arXiv:2407.05322](https://arxiv.org/abs/2407.05322), with a more in-depth explanation of dependent vs. independent assumptions in Sec.\u00a03.2."
    ]
   },
   {
@@ -300,7 +300,7 @@
     "\n",
     "for eps in eps_grid:\n",
     "    base_info = deepcopy(base_info)\n",
-    "    base_info['syst']['sys1']['epsilon'] = float(eps)\n",
+    "    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)\n",
     "    comb.update_data(base_info)\n",
     "    cv.append(comb.fit_results['mu'])\n",
     "    lower_bound.append(comb.confidence_interval()[0])\n",
@@ -443,7 +443,7 @@
     "\n",
     "for eps in eps_grid:\n",
     "    base_info = deepcopy(base_info)\n",
-    "    base_info['syst']['sys1']['epsilon'] = float(eps)\n",
+    "    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)\n",
     "    comb.update_data(base_info)\n",
     "    cv.append(comb.fit_results['mu'])\n",
     "    lower_bound.append(comb.confidence_interval()[0])\n",
@@ -588,7 +588,7 @@
     "\n",
     "for eps in eps_grid:\n",
     "    base_info = deepcopy(base_info)\n",
-    "    base_info['syst']['sys1']['epsilon'] = float(eps)\n",
+    "    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)\n",
     "    comb.update_data(base_info)\n",
     "    cv.append(comb.fit_results['mu'])\n",
     "    lower_bound.append(comb.confidence_interval()[0])\n",
@@ -727,7 +727,7 @@
     "\n",
     "for eps in eps_grid:\n",
     "    base_info = deepcopy(base_info)\n",
-    "    base_info['syst']['sys1']['epsilon'] = float(eps)\n",
+    "    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)\n",
     "    comb.update_data(base_info)\n",
     "    cv.append(comb.fit_results['mu'])\n",
     "    lower_bound.append(comb.confidence_interval()[0])\n",
@@ -824,7 +824,7 @@
     "\n",
     "for eps in eps_grid:\n",
     "    base_info = deepcopy(base_info)\n",
-    "    base_info['syst']['sys1']['epsilon'] = float(eps)\n",
+    "    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)\n",
     "    comb.update_data(base_info)\n",
     "    cv.append(comb.fit_results['mu'])  \n",
     "    lower_bound.append(comb.confidence_interval()[0])\n",
@@ -901,9 +901,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:errors-on-errors]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-errors-on-errors-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/toy/tutorial.md
+++ b/tutorials/toy/tutorial.md
@@ -37,7 +37,7 @@ global:
   name: decorrelated
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   measurements:
@@ -46,13 +46,16 @@ data:
       stat_error: 1.0
     - label: m2
       central: -1.5
-      stat_error: 1.
+      stat_error: 1.0
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type: independent
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: diagonal
+    error-on-error:
+      value: 0.0
+      type: independent
 ```
 
 
@@ -87,7 +90,7 @@ We now compare three different correlation matrices for the systematic uncertain
      name: diag_corr
      n_meas: 2
      n_syst: 1
-     corr_dir: tutorials/toy/input_files/correlations
+   corr_dir: input_files/correlations
 
    data:
      measurements:
@@ -100,10 +103,12 @@ We now compare three different correlation matrices for the systematic uncertain
 
    syst:
      - name: sys1
-       shifts: [0.5, 1.0]
-       type:
-         dependent: diagonal
-       epsilon: 0.0
+       shift:
+         value: [0.5, 1.0]
+         correlation: diagonal
+       error-on-error:
+         value: 0.0
+         type: dependent
    ```
 
    The diagonal option corresponds to:
@@ -120,7 +125,7 @@ We now compare three different correlation matrices for the systematic uncertain
      name: hybrid_corr
      n_meas: 2
      n_syst: 1
-     corr_dir: tutorials/toy/input_files/correlations
+   corr_dir: input_files/correlations
 
    data:
      measurements:
@@ -133,10 +138,12 @@ We now compare three different correlation matrices for the systematic uncertain
 
    syst:
      - name: sys1
-       shifts: [0.5, 1.0]
-       type:
-         dependent: hybrid_corr.txt
-       epsilon: 0.0
+       shift:
+         value: [0.5, 1.0]
+         correlation: hybrid_corr.txt
+       error-on-error:
+         value: 0.0
+         type: dependent
    ```
 
    `hybrid_corr.txt`
@@ -153,7 +160,7 @@ We now compare three different correlation matrices for the systematic uncertain
      name: full_corr
      n_meas: 2
      n_syst: 1
-     corr_dir: tutorials/toy/input_files/correlations
+   corr_dir: input_files/correlations
 
    data:
      measurements:
@@ -166,10 +173,12 @@ We now compare three different correlation matrices for the systematic uncertain
 
    syst:
      - name: sys1
-       shifts: [0.5, 1.0]
-       type:
-         dependent: ones
-       epsilon: 0.0
+       shift:
+         value: [0.5, 1.0]
+         correlation: ones
+       error-on-error:
+         value: 0.0
+         type: dependent
    ```
 
    The ones option corresponds to:
@@ -235,7 +244,7 @@ global:
   name: stat_cov
   n_meas: 2
   n_syst: 1
-  corr_dir: tutorials/toy/input_files/correlations
+  corr_dir: input_files/correlations
 
 data:
   stat_cov_path: stat_cov.txt
@@ -247,10 +256,12 @@ data:
 
 syst:
   - name: sys1
-    shifts: [0.5, 1.0]
-    type:
-      dependent: ones
-    epsilon: 0.0
+    shift:
+      value: [0.5, 1.0]
+      correlation: ones
+    error-on-error:
+      value: 0.0
+      type: dependent
 ```
 
 `stat_cov.txt`
@@ -294,11 +305,11 @@ info = comb.input_data()
 
 # change measurement and systematic values
 info['data']['measurements']['m1']['central'] = 2.0
-info['syst']['sys1']['values']['m1'] = 0.5
+info['syst']['sys1']['shift']['value']['m1'] = 0.5
 
 # update the systematic to be dependent with a new correlation matrix
-info['syst']['sys1']['type'] = 'dependent'
-info['syst']['sys1']['corr'] = np.array([[1.0, 0.3], [0.3, 1.0]])
+info['syst']['sys1']['error-on-error']['type'] = 'dependent'
+info['syst']['sys1']['shift']['correlation'] = np.array([[1.0, 0.3], [0.3, 1.0]])
 
 # apply modifications and refit
 comb.update_data(info)
@@ -346,7 +357,7 @@ sign = []
 
 for eps in eps_grid:
     base_info = deepcopy(base_info)
-    base_info['syst']['sys1']['epsilon'] = float(eps)
+    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)
     comb.update_data(base_info)
     cv.append(comb.fit_results['mu'])
     lower_bound.append(comb.confidence_interval()[0])
@@ -448,7 +459,7 @@ sign = []
 
 for eps in eps_grid:
     base_info = deepcopy(base_info)
-    base_info['syst']['sys1']['epsilon'] = float(eps)
+    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)
     comb.update_data(base_info)
     cv.append(comb.fit_results['mu'])
     lower_bound.append(comb.confidence_interval()[0])
@@ -552,7 +563,7 @@ sign = []
 
 for eps in eps_grid:
     base_info = deepcopy(base_info)
-    base_info['syst']['sys1']['epsilon'] = float(eps)
+    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)
     comb.update_data(base_info)
     cv.append(comb.fit_results['mu'])
     lower_bound.append(comb.confidence_interval()[0])
@@ -650,7 +661,7 @@ sign = []
 
 for eps in eps_grid:
     base_info = deepcopy(base_info)
-    base_info['syst']['sys1']['epsilon'] = float(eps)
+    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)
     comb.update_data(base_info)
     cv.append(comb.fit_results['mu'])
     lower_bound.append(comb.confidence_interval()[0])
@@ -724,7 +735,7 @@ sign = []
 
 for eps in eps_grid:
     base_info = deepcopy(base_info)
-    base_info['syst']['sys1']['epsilon'] = float(eps)
+    base_info['syst']['sys1']['error-on-error']['value'] = float(eps)
     comb.update_data(base_info)
     cv.append(comb.fit_results['mu'])  
     lower_bound.append(comb.confidence_interval()[0])


### PR DESCRIPTION
## Summary
- adapt toy tutorial configs to the new `shift`/`error-on-error` schema
- rewrite tutorial text and notebook code to use `error-on-error` API
- point configs to local correlation directory for notebook execution

## Testing
- `python - <<'PY'
import os
from gvm_toolkit import GVMCombination
os.chdir('tutorials/toy')
for name in ['decorrelated','diag_corr','hybrid_corr','full_corr','stat_cov']:
    path=f'input_files/{name}.yaml'
    comb=GVMCombination(path)
    print(name, round(comb.fit_results['mu'],4))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68908d21f2d0832cb1c7e790740f5c60