### PR TITLE
Default error-on-error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ sections:
   toolkit constructs the full covariance matrix.
 * ``syst`` – list of systematics. Each has a ``shift`` block with ``value``
   listing the shifts for each measurement and ``correlation`` specifying
-  ``diagonal``, ``ones`` or a path to a correlation matrix. An
+  ``diagonal``, ``ones`` or a path to a correlation matrix. An optional
   ``error-on-error`` block specifies the ``value`` and ``type``
-  (``dependent`` or ``independent``).
+  (``dependent`` or ``independent``). If omitted, the value defaults to ``0``
+  and the type to ``dependent``.
 A minimal configuration:
 
 ```yaml

--- a/gvm_toolkit.py
+++ b/gvm_toolkit.py
@@ -138,14 +138,9 @@ class GVMCombination:
                     path_corr = os.path.join(corr_dir, path_corr)
                 corr = np.loadtxt(path_corr, dtype=float)
 
-            try:
-                eoe = item['error-on-error']
-                eps_val = float(eoe['value'])
-                eps_type = eoe['type']
-            except KeyError as exc:
-                raise KeyError(
-                    f'Systematic "{name}" must define "error-on-error.value" and "error-on-error.type"'
-                ) from exc
+            eoe = item.get('error-on-error', {})
+            eps_val = float(eoe.get('value', 0.0))
+            eps_type = eoe.get('type', 'dependent')
             if eps_type not in ('dependent', 'independent'):
                 raise ValueError(
                     f'Systematic "{name}" has unrecognised error-on-error type "{eps_type}"'


### PR DESCRIPTION
## Summary
- Allow missing `error-on-error` values: default to 0 and type `dependent`
- Document optional `error-on-error` block and its defaults

## Testing
- `pytest -q`
- `python gvm_toolkit.py` sanity test parsing config without `error-on-error`

------
https://chatgpt.com/codex/tasks/task_e_6890a7fb3f14832ca712520001781d26