### PR TITLE
Support vector epsilon for independent systematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ sections:
   listing the shifts for each measurement and ``correlation`` specifying
   ``diagonal``, ``ones`` or a path to a correlation matrix. An optional
   ``error-on-error`` block specifies the ``value`` and ``type``
-  (``dependent`` or ``independent``). If omitted, the value defaults to ``0``
-  and the type to ``dependent``.
+  (``dependent`` or ``independent``). For ``independent`` systematics the
+  ``value`` may be either a list giving one epsilon per measurement or a
+  single number which is applied to all measurements. If omitted, the value
+  defaults to ``0`` and the type to ``dependent``.
 A minimal configuration:
 
 ```yaml


### PR DESCRIPTION
## Summary
- Allow independent systematic errors to specify epsilon per measurement or a single value expanded to a vector.
- Validate epsilon vector lengths and apply element-wise epsilon in likelihood, FIM and Bartlett corrections.
- Document epsilon list/scalar behaviour for independent systematics.

## Testing
- `python -m py_compile gvm_toolkit.py`
- `python - <<'PY'
from gvm_toolkit import GVMCombination
cfg_scalar = '''
global:
  name: TestScalar
  n_meas: 2
  n_syst: 1

data:
  measurements:
    - label: A
      central: 1.0
      stat_error: 0.1
    - label: B
      central: 1.2
      stat_error: 0.1

syst:
  - name: scale
    shift:
      value: [0.05, -0.02]
      correlation: diagonal
    error-on-error:
      value: 0.3
      type: independent
'''
open('cfg_scalar.yaml','w').write(cfg_scalar)
scalar = GVMCombination('cfg_scalar.yaml')
print('scalar eps:', scalar.uncertain_systematics['scale'])

cfg_list = cfg_scalar.replace('TestScalar','TestList').replace('0.3','[0.1, 0.2]')
open('cfg_list.yaml','w').write(cfg_list)
list_comb = GVMCombination('cfg_list.yaml')
print('list eps:', list_comb.uncertain_systematics['scale'])
PY`
- `python - <<'PY'
from gvm_toolkit import GVMCombination
cfg = '''
global:
  name: TestGOF
  n_meas: 2
  n_syst: 1

data:
  measurements:
    - label: A
      central: 1.0
      stat_error: 0.1
    - label: B
      central: 1.2
      stat_error: 0.1

syst:
  - name: scale
    shift:
      value: [0.05, -0.02]
      correlation: diagonal
    error-on-error:
      value: [0.1, 0.2]
      type: independent
'''
open('cfg_gof.yaml','w').write(cfg)
comb = GVMCombination('cfg_gof.yaml')
print('gof:', comb.goodness_of_fit())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6891e16c186c832c89225bef4bdb034f