### PR TITLE
Update top mass tutorial for new toolkit

### DIFF
--- a/tutorials/top-mass/input_files/LHC_comb.yaml
+++ b/tutorials/top-mass/input_files/LHC_comb.yaml
@@ -1,160 +1,603 @@
-# -----------------------------------------------------------------
-#  File:  LHC_mass_combination.yaml
-#  Schema version: 1
-# -----------------------------------------------------------------
-
 global:
-  corr_dir:      input_files/correlations/
+  corr_dir: input_files/correlations
   n_meas: 15
   n_syst: 25
   name: LHC
-
 data:
   measurements:
-    - label: a
-      central: 173.79
-      stat_error: 0.54
-    - label: b
-      central: 172.33
-      stat_error: 0.75
-    - label: c
-      central: 175.06
-      stat_error: 1.35
-    - label: d
-      central: 172.99
-      stat_error: 0.41
-    - label: e
-      central: 172.08
-      stat_error: 0.39
-    - label: f
-      central: 173.72
-      stat_error: 0.55
-    - label: g
-      central: 172.50
-      stat_error: 0.43
-    - label: h
-      central: 173.49
-      stat_error: 0.43
-    - label: i
-      central: 173.49
-      stat_error: 0.69
-    - label: j
-      central: 172.22
-      stat_error: 0.18
-    - label: k
-      central: 172.35
-      stat_error: 0.16
-    - label: l
-      central: 172.32
-      stat_error: 0.25
-    - label: m
-      central: 172.95
-      stat_error: 0.77
-    - label: n
-      central: 173.50
-      stat_error: 3.00
-    - label: o
-      central: 173.68
-      stat_error: 0.20
-
+  - label: a
+    central: 173.79
+    stat_error: 0.54
+  - label: b
+    central: 172.33
+    stat_error: 0.75
+  - label: c
+    central: 175.06
+    stat_error: 1.35
+  - label: d
+    central: 172.99
+    stat_error: 0.41
+  - label: e
+    central: 172.08
+    stat_error: 0.39
+  - label: f
+    central: 173.72
+    stat_error: 0.55
+  - label: g
+    central: 172.5
+    stat_error: 0.43
+  - label: h
+    central: 173.49
+    stat_error: 0.43
+  - label: i
+    central: 173.49
+    stat_error: 0.69
+  - label: j
+    central: 172.22
+    stat_error: 0.18
+  - label: k
+    central: 172.35
+    stat_error: 0.16
+  - label: l
+    central: 172.32
+    stat_error: 0.25
+  - label: m
+    central: 172.95
+    stat_error: 0.77
+  - label: n
+    central: 173.5
+    stat_error: 3.0
+  - label: o
+    central: 173.68
+    stat_error: 0.2
 syst:
-  - name: LHCJES1
-    shifts: [0.54, 0.33, 0.38, 0.35, 0.28, 0.40, 0.77, 0.24, 0.69, 0.31, 0.10, 0.16, 0.40, 0.00, 0.11]
-    corr_file: LHCJES1.txt
-    epsilon: 0.00
-  - name: LHCJES2
-    shifts: [0.30, 0.30, 0.20, 0.41, 0.39, 0.42, 0.54, 0.02, 0.35, 0.17, 0.12, 0.19, 0.21, 0.00, 0.13]
-    corr_file: LHCJES2.txt
-    epsilon: 0.00
-  - name: LHCJES3
-    shifts: [0.43, 0.07, 0.24, 0.08, 0.05, 0.12, 0.06, 0.01, 0.08, 0.03, 0.01, 0.02, 0.05, 0.00, 0.01]
-    corr_file: LHCJES3.txt
-    epsilon: 0.00
-  - name: LHCbJES
-    shifts: [0.68, 0.06, 0.62, 0.30, 0.03, 0.34, 0.70, 0.61, 0.49, 0.37, 0.32, 0.29, 0.38, 0.00, 0.00]
-    corr_file: LHCbJES.txt
-    epsilon: 0.00
-  - name: LHCgJES
-    shifts: [0.03, 0.28, 0.10, 0.02, 0.21, 0.05, 0.00, 0.00, 0.00, 0.07, 0.08, 0.02, 0.00, 0.00, 0.00]
-    corr_file: LHCgJES.txt
-    epsilon: 0.00
-  - name: LHClJES
-    shifts: [0.02, 0.24, 0.02, 0.01, 0.10, 0.06, 0.00, 0.00, 0.00, 0.04, 0.06, 0.01, 0.07, 0.00, 0.00]
-    corr_file: LHClJES.txt
-    epsilon: 0.00
-  - name: CMSJES
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.58, 0.11, 0.58, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
-    corr_file: CMSJES.txt
-    epsilon: 0.00
-  - name: JER
-    shifts: [0.19, 0.22, 0.01, 0.09, 0.20, 0.10, 0.14, 0.23, 0.15, 0.00, 0.03, 0.02, 0.05, 0.00, 0.05]
-    corr_file: JER.txt
-    epsilon: 0.00
-  - name: leptons
-    shifts: [0.13, 0.04, 0.00, 0.14, 0.16, 0.01, 0.14, 0.02, 0.00, 0.25, 0.01, 0.00, 0.05, 0.10, 0.24]
-    corr_file: leptons.txt
-    epsilon: 0.00
-  - name: btag
-    shifts: [0.07, 0.50, 0.16, 0.04, 0.38, 0.10, 0.09, 0.12, 0.06, 0.01, 0.06, 0.02, 0.10, 0.00, 0.02]
-    corr_file: btag.txt
-    epsilon: 0.00
-  - name: ptmiss
-    shifts: [0.04, 0.15, 0.02, 0.01, 0.05, 0.01, 0.12, 0.06, 0.00, 0.01, 0.04, 0.00, 0.15, 0.00, 0.00]
-    corr_file: ptmiss.txt
-    epsilon: 0.00
-  - name: pileup
-    shifts: [0.01, 0.02, 0.02, 0.05, 0.15, 0.01, 0.11, 0.07, 0.06, 0.05, 0.06, 0.06, 0.14, 0.07, 0.05]
-    corr_file: pileup.txt
-    epsilon: 0.00
-  - name: trigger
-    shifts: [0.01, 0.00, 0.01, 0.00, 0.01, 0.08, 0.00, 0.00, 0.24, 0.00, 0.00, 0.01, 0.00, 0.02, 0.00]
-    corr_file: trigger.txt
-    epsilon: 0.00
-  - name: ME
-    shifts: [0.26, 0.22, 0.30, 0.09, 0.16, 0.18, 0.04, 0.02, 0.19, 0.07, 0.12, 0.16, 0.00, 0.37, 0.42]
-    corr_file: ME.txt
-    epsilon: 0.00
-  - name: LHCrad
-    shifts: [0.47, 0.32, 0.22, 0.23, 0.08, 0.10, 0.58, 0.30, 0.33, 0.24, 0.09, 0.18, 0.35, 0.74, 0.20]
-    corr_file: LHCrad.txt
-    epsilon: 0.00
-  - name: LHChad
-    shifts: [0.53, 0.18, 0.50, 0.22, 0.15, 0.64, 0.00, 0.00, 0.00, 0.38, 0.01, 0.04, 0.00, 0.30, 0.54]
-    corr_file: LHChad.txt
-    epsilon: 0.00
-  - name: CMSbHad
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.12, 0.16, 0.13, 0.15, 0.00, 0.16]
-    corr_file: CMSbHad.txt
-    epsilon: 0.00
-  - name: CR
-    shifts: [0.14, 0.11, 0.22, 0.03, 0.19, 0.12, 0.13, 0.54, 0.15, 0.13, 0.01, 0.16, 0.05, 0.12, 0.08]
-    corr_file: CR.txt
-    epsilon: 0.00
-  - name: UE
-    shifts: [0.05, 0.15, 0.08, 0.10, 0.08, 0.12, 0.05, 0.15, 0.20, 0.11, 0.08, 0.14, 0.20, 0.13, 0.00]
-    corr_file: UE.txt
-    epsilon: 0.00
-  - name: PDF
-    shifts: [0.10, 0.25, 0.09, 0.05, 0.09, 0.09, 0.09, 0.07, 0.06, 0.17, 0.04, 0.03, 0.11, 0.11, 0.04]
-    corr_file: PDF.txt
-    epsilon: 0.00
-  - name: topPT
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.51, 0.02, 0.06, 0.00, 0.00, 0.00]
-    corr_file: topPT.txt
-    epsilon: 0.00
-  - name: bkgData
-    shifts: [0.04, 0.11, 0.35, 0.07, 0.05, 0.17, 0.00, 0.00, 0.13, 0.00, 0.00, 0.20, 0.00, 0.00, 0.44]
-    corr_file: bkgData.txt
-    epsilon: 0.00
-  - name: bkgMC
-    shifts: [0.01, 0.29, 0.00, 0.03, 0.13, 0.00, 0.05, 0.13, 0.00, 0.00, 0.03, 0.00, 0.17, 0.01, 0.00]
-    corr_file: bkgMC.txt
-    epsilon: 0.00
-  - name: method
-    shifts: [0.09, 0.11, 0.42, 0.05, 0.13, 0.11, 0.40, 0.06, 0.13, 0.00, 0.04, 0.06, 0.39, 0.22, 0.62]
-    corr_file: method.txt
-    epsilon: 0.00
-  - name: other
-    shifts: [0.07, 0.12, 0.24, 0.02, 0.10, 0.03, 0.00, 0.00, 0.00, 0.03, 0.00, 0.00, 0.25, 0.09, 0.09]
-    corr_file: other.txt
-    epsilon: 0.00
+- name: LHCJES1
+  shift:
+    value:
+    - 0.54
+    - 0.33
+    - 0.38
+    - 0.35
+    - 0.28
+    - 0.4
+    - 0.77
+    - 0.24
+    - 0.69
+    - 0.31
+    - 0.1
+    - 0.16
+    - 0.4
+    - 0.0
+    - 0.11
+    correlation: LHCJES1.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCJES2
+  shift:
+    value:
+    - 0.3
+    - 0.3
+    - 0.2
+    - 0.41
+    - 0.39
+    - 0.42
+    - 0.54
+    - 0.02
+    - 0.35
+    - 0.17
+    - 0.12
+    - 0.19
+    - 0.21
+    - 0.0
+    - 0.13
+    correlation: LHCJES2.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCJES3
+  shift:
+    value:
+    - 0.43
+    - 0.07
+    - 0.24
+    - 0.08
+    - 0.05
+    - 0.12
+    - 0.06
+    - 0.01
+    - 0.08
+    - 0.03
+    - 0.01
+    - 0.02
+    - 0.05
+    - 0.0
+    - 0.01
+    correlation: LHCJES3.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCbJES
+  shift:
+    value:
+    - 0.68
+    - 0.06
+    - 0.62
+    - 0.3
+    - 0.03
+    - 0.34
+    - 0.7
+    - 0.61
+    - 0.49
+    - 0.37
+    - 0.32
+    - 0.29
+    - 0.38
+    - 0.0
+    - 0.0
+    correlation: LHCbJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCgJES
+  shift:
+    value:
+    - 0.03
+    - 0.28
+    - 0.1
+    - 0.02
+    - 0.21
+    - 0.05
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.07
+    - 0.08
+    - 0.02
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: LHCgJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHClJES
+  shift:
+    value:
+    - 0.02
+    - 0.24
+    - 0.02
+    - 0.01
+    - 0.1
+    - 0.06
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.04
+    - 0.06
+    - 0.01
+    - 0.07
+    - 0.0
+    - 0.0
+    correlation: LHClJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CMSJES
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.58
+    - 0.11
+    - 0.58
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: CMSJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: JER
+  shift:
+    value:
+    - 0.19
+    - 0.22
+    - 0.01
+    - 0.09
+    - 0.2
+    - 0.1
+    - 0.14
+    - 0.23
+    - 0.15
+    - 0.0
+    - 0.03
+    - 0.02
+    - 0.05
+    - 0.0
+    - 0.05
+    correlation: JER.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: leptons
+  shift:
+    value:
+    - 0.13
+    - 0.04
+    - 0.0
+    - 0.14
+    - 0.16
+    - 0.01
+    - 0.14
+    - 0.02
+    - 0.0
+    - 0.25
+    - 0.01
+    - 0.0
+    - 0.05
+    - 0.1
+    - 0.24
+    correlation: leptons.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: btag
+  shift:
+    value:
+    - 0.07
+    - 0.5
+    - 0.16
+    - 0.04
+    - 0.38
+    - 0.1
+    - 0.09
+    - 0.12
+    - 0.06
+    - 0.01
+    - 0.06
+    - 0.02
+    - 0.1
+    - 0.0
+    - 0.02
+    correlation: btag.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: ptmiss
+  shift:
+    value:
+    - 0.04
+    - 0.15
+    - 0.02
+    - 0.01
+    - 0.05
+    - 0.01
+    - 0.12
+    - 0.06
+    - 0.0
+    - 0.01
+    - 0.04
+    - 0.0
+    - 0.15
+    - 0.0
+    - 0.0
+    correlation: ptmiss.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: pileup
+  shift:
+    value:
+    - 0.01
+    - 0.02
+    - 0.02
+    - 0.05
+    - 0.15
+    - 0.01
+    - 0.11
+    - 0.07
+    - 0.06
+    - 0.05
+    - 0.06
+    - 0.06
+    - 0.14
+    - 0.07
+    - 0.05
+    correlation: pileup.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: trigger
+  shift:
+    value:
+    - 0.01
+    - 0.0
+    - 0.01
+    - 0.0
+    - 0.01
+    - 0.08
+    - 0.0
+    - 0.0
+    - 0.24
+    - 0.0
+    - 0.0
+    - 0.01
+    - 0.0
+    - 0.02
+    - 0.0
+    correlation: trigger.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: ME
+  shift:
+    value:
+    - 0.26
+    - 0.22
+    - 0.3
+    - 0.09
+    - 0.16
+    - 0.18
+    - 0.04
+    - 0.02
+    - 0.19
+    - 0.07
+    - 0.12
+    - 0.16
+    - 0.0
+    - 0.37
+    - 0.42
+    correlation: ME.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCrad
+  shift:
+    value:
+    - 0.47
+    - 0.32
+    - 0.22
+    - 0.23
+    - 0.08
+    - 0.1
+    - 0.58
+    - 0.3
+    - 0.33
+    - 0.24
+    - 0.09
+    - 0.18
+    - 0.35
+    - 0.74
+    - 0.2
+    correlation: LHCrad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHChad
+  shift:
+    value:
+    - 0.53
+    - 0.18
+    - 0.5
+    - 0.22
+    - 0.15
+    - 0.64
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.38
+    - 0.01
+    - 0.04
+    - 0.0
+    - 0.3
+    - 0.54
+    correlation: LHChad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CMSbHad
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.12
+    - 0.16
+    - 0.13
+    - 0.15
+    - 0.0
+    - 0.16
+    correlation: CMSbHad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CR
+  shift:
+    value:
+    - 0.14
+    - 0.11
+    - 0.22
+    - 0.03
+    - 0.19
+    - 0.12
+    - 0.13
+    - 0.54
+    - 0.15
+    - 0.13
+    - 0.01
+    - 0.16
+    - 0.05
+    - 0.12
+    - 0.08
+    correlation: CR.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: UE
+  shift:
+    value:
+    - 0.05
+    - 0.15
+    - 0.08
+    - 0.1
+    - 0.08
+    - 0.12
+    - 0.05
+    - 0.15
+    - 0.2
+    - 0.11
+    - 0.08
+    - 0.14
+    - 0.2
+    - 0.13
+    - 0.0
+    correlation: UE.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: PDF
+  shift:
+    value:
+    - 0.1
+    - 0.25
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.09
+    - 0.07
+    - 0.06
+    - 0.17
+    - 0.04
+    - 0.03
+    - 0.11
+    - 0.11
+    - 0.04
+    correlation: PDF.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: topPT
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.51
+    - 0.02
+    - 0.06
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: topPT.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: bkgData
+  shift:
+    value:
+    - 0.04
+    - 0.11
+    - 0.35
+    - 0.07
+    - 0.05
+    - 0.17
+    - 0.0
+    - 0.0
+    - 0.13
+    - 0.0
+    - 0.0
+    - 0.2
+    - 0.0
+    - 0.0
+    - 0.44
+    correlation: bkgData.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: bkgMC
+  shift:
+    value:
+    - 0.01
+    - 0.29
+    - 0.0
+    - 0.03
+    - 0.13
+    - 0.0
+    - 0.05
+    - 0.13
+    - 0.0
+    - 0.0
+    - 0.03
+    - 0.0
+    - 0.17
+    - 0.01
+    - 0.0
+    correlation: bkgMC.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: method
+  shift:
+    value:
+    - 0.09
+    - 0.11
+    - 0.42
+    - 0.05
+    - 0.13
+    - 0.11
+    - 0.4
+    - 0.06
+    - 0.13
+    - 0.0
+    - 0.04
+    - 0.06
+    - 0.39
+    - 0.22
+    - 0.62
+    correlation: method.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: other
+  shift:
+    value:
+    - 0.07
+    - 0.12
+    - 0.24
+    - 0.02
+    - 0.1
+    - 0.03
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.03
+    - 0.0
+    - 0.0
+    - 0.25
+    - 0.09
+    - 0.09
+    correlation: other.txt
+  error-on-error:
+    value: 0.0
+    type: dependent

--- a/tutorials/top-mass/input_files/LHC_comb_fictitious_meas.yaml
+++ b/tutorials/top-mass/input_files/LHC_comb_fictitious_meas.yaml
@@ -1,166 +1,654 @@
-# -----------------------------------------------------------------
-#  File:  LHC_mass_combination.yaml
-#  Schema version: 1
-# -----------------------------------------------------------------
-
 global:
-  corr_dir:      input_files/correlations/
+  corr_dir: input_files/correlations
   n_meas: 16
   n_syst: 26
   name: LHC
-
 data:
   measurements:
-    - label: a
-      central: 173.79
-      stat_error: 0.54
-    - label: b
-      central: 172.33
-      stat_error: 0.75
-    - label: c
-      central: 175.06
-      stat_error: 1.35
-    - label: d
-      central: 172.99
-      stat_error: 0.41
-    - label: e
-      central: 172.08
-      stat_error: 0.39
-    - label: f
-      central: 173.72
-      stat_error: 0.55
-    - label: g
-      central: 172.50
-      stat_error: 0.43
-    - label: h
-      central: 173.49
-      stat_error: 0.43
-    - label: i
-      central: 173.49
-      stat_error: 0.69
-    - label: j
-      central: 172.22
-      stat_error: 0.18
-    - label: k
-      central: 172.35
-      stat_error: 0.16
-    - label: l
-      central: 172.32
-      stat_error: 0.25
-    - label: m
-      central: 172.95
-      stat_error: 0.77
-    - label: n
-      central: 173.50
-      stat_error: 3.00
-    - label: o
-      central: 173.68
-      stat_error: 0.20
-    - label: new
-      central: 174.5
-      stat_error: 0.4
-      
+  - label: a
+    central: 173.79
+    stat_error: 0.54
+  - label: b
+    central: 172.33
+    stat_error: 0.75
+  - label: c
+    central: 175.06
+    stat_error: 1.35
+  - label: d
+    central: 172.99
+    stat_error: 0.41
+  - label: e
+    central: 172.08
+    stat_error: 0.39
+  - label: f
+    central: 173.72
+    stat_error: 0.55
+  - label: g
+    central: 172.5
+    stat_error: 0.43
+  - label: h
+    central: 173.49
+    stat_error: 0.43
+  - label: i
+    central: 173.49
+    stat_error: 0.69
+  - label: j
+    central: 172.22
+    stat_error: 0.18
+  - label: k
+    central: 172.35
+    stat_error: 0.16
+  - label: l
+    central: 172.32
+    stat_error: 0.25
+  - label: m
+    central: 172.95
+    stat_error: 0.77
+  - label: n
+    central: 173.5
+    stat_error: 3.0
+  - label: o
+    central: 173.68
+    stat_error: 0.2
+  - label: new
+    central: 174.5
+    stat_error: 0.4
 syst:
-  - name: LHCJES1
-    shifts: [0.54, 0.33, 0.38, 0.35, 0.28, 0.40, 0.77, 0.24, 0.69, 0.31, 0.10, 0.16, 0.40, 0.00, 0.11, 0.00]
-    corr_file: LHCJES1.txt
-    epsilon: 0.00
-  - name: LHCJES2
-    shifts: [0.30, 0.30, 0.20, 0.41, 0.39, 0.42, 0.54, 0.02, 0.35, 0.17, 0.12, 0.19, 0.21, 0.00, 0.13, 0.00]
-    corr_file: LHCJES2.txt
-    epsilon: 0.00
-  - name: LHCJES3
-    shifts: [0.43, 0.07, 0.24, 0.08, 0.05, 0.12, 0.06, 0.01, 0.08, 0.03, 0.01, 0.02, 0.05, 0.00, 0.01, 0.00]
-    corr_file: LHCJES3.txt
-    epsilon: 0.00
-  - name: LHCbJES
-    shifts: [0.68, 0.06, 0.62, 0.30, 0.03, 0.34, 0.70, 0.61, 0.49, 0.37, 0.32, 0.29, 0.38, 0.00, 0.00, 0.00]
-    corr_file: LHCbJES.txt
-    epsilon: 0.00
-  - name: LHCgJES
-    shifts: [0.03, 0.28, 0.10, 0.02, 0.21, 0.05, 0.00, 0.00, 0.00, 0.07, 0.08, 0.02, 0.00, 0.00, 0.00, 0.00]
-    corr_file: LHCgJES.txt
-    epsilon: 0.00
-  - name: LHClJES
-    shifts: [0.02, 0.24, 0.02, 0.01, 0.10, 0.06, 0.00, 0.00, 0.00, 0.04, 0.06, 0.01, 0.07, 0.00, 0.00, 0.00]
-    corr_file: LHClJES.txt
-    epsilon: 0.00
-  - name: CMSJES
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.58, 0.11, 0.58, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
-    corr_file: CMSJES.txt
-    epsilon: 0.00
-  - name: JER
-    shifts: [0.19, 0.22, 0.01, 0.09, 0.20, 0.10, 0.14, 0.23, 0.15, 0.00, 0.03, 0.02, 0.05, 0.00, 0.05, 0.00]
-    corr_file: JER.txt
-    epsilon: 0.00
-  - name: leptons
-    shifts: [0.13, 0.04, 0.00, 0.14, 0.16, 0.01, 0.14, 0.02, 0.00, 0.25, 0.01, 0.00, 0.05, 0.10, 0.24, 0.00]
-    corr_file: leptons.txt
-    epsilon: 0.00
-  - name: btag
-    shifts: [0.07, 0.50, 0.16, 0.04, 0.38, 0.10, 0.09, 0.12, 0.06, 0.01, 0.06, 0.02, 0.10, 0.00, 0.02, 0.00]
-    corr_file: btag.txt
-    epsilon: 0.00
-  - name: ptmiss
-    shifts: [0.04, 0.15, 0.02, 0.01, 0.05, 0.01, 0.12, 0.06, 0.00, 0.01, 0.04, 0.00, 0.15, 0.00, 0.00, 0.00]
-    corr_file: ptmiss.txt
-    epsilon: 0.00
-  - name: pileup
-    shifts: [0.01, 0.02, 0.02, 0.05, 0.15, 0.01, 0.11, 0.07, 0.06, 0.05, 0.06, 0.06, 0.14, 0.07, 0.05, 0.00]
-    corr_file: pileup.txt
-    epsilon: 0.00
-  - name: trigger
-    shifts: [0.01, 0.00, 0.01, 0.00, 0.01, 0.08, 0.00, 0.00, 0.24, 0.00, 0.00, 0.01, 0.00, 0.02, 0.00, 0.00]
-    corr_file: trigger.txt
-    epsilon: 0.00
-  - name: ME
-    shifts: [0.26, 0.22, 0.30, 0.09, 0.16, 0.18, 0.04, 0.02, 0.19, 0.07, 0.12, 0.16, 0.00, 0.37, 0.42, 0.00]
-    corr_file: ME.txt
-    epsilon: 0.00
-  - name: LHCrad
-    shifts: [0.47, 0.32, 0.22, 0.23, 0.08, 0.10, 0.58, 0.30, 0.33, 0.24, 0.09, 0.18, 0.35, 0.74, 0.20, 0.00]
-    corr_file: LHCrad.txt
-    epsilon: 0.00
-  - name: LHChad
-    shifts: [0.53, 0.18, 0.50, 0.22, 0.15, 0.64, 0.00, 0.00, 0.00, 0.38, 0.01, 0.04, 0.00, 0.30, 0.54, 0.00]
-    corr_file: LHChad.txt
-    epsilon: 0.00
-  - name: CMSbHad
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.12, 0.16, 0.13, 0.15, 0.00, 0.16, 0.00]
-    corr_file: CMSbHad.txt
-    epsilon: 0.00
-  - name: CR
-    shifts: [0.14, 0.11, 0.22, 0.03, 0.19, 0.12, 0.13, 0.54, 0.15, 0.13, 0.01, 0.16, 0.05, 0.12, 0.08, 0.00]
-    corr_file: CR.txt
-    epsilon: 0.00
-  - name: UE
-    shifts: [0.05, 0.15, 0.08, 0.10, 0.08, 0.12, 0.05, 0.15, 0.20, 0.11, 0.08, 0.14, 0.20, 0.13, 0.00, 0.00]
-    corr_file: UE.txt
-    epsilon: 0.00
-  - name: PDF
-    shifts: [0.10, 0.25, 0.09, 0.05, 0.09, 0.09, 0.09, 0.07, 0.06, 0.17, 0.04, 0.03, 0.11, 0.11, 0.04, 0.00]
-    corr_file: PDF.txt
-    epsilon: 0.00
-  - name: topPT
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.51, 0.02, 0.06, 0.00, 0.00, 0.00, 0.00]
-    corr_file: topPT.txt
-    epsilon: 0.00
-  - name: bkgData
-    shifts: [0.04, 0.11, 0.35, 0.07, 0.05, 0.17, 0.00, 0.00, 0.13, 0.00, 0.00, 0.20, 0.00, 0.00, 0.44, 0.00]
-    corr_file: bkgData.txt
-    epsilon: 0.00
-  - name: bkgMC
-    shifts: [0.01, 0.29, 0.00, 0.03, 0.13, 0.00, 0.05, 0.13, 0.00, 0.00, 0.03, 0.00, 0.17, 0.01, 0.00, 0.00]
-    corr_file: bkgMC.txt
-    epsilon: 0.00
-  - name: method
-    shifts: [0.09, 0.11, 0.42, 0.05, 0.13, 0.11, 0.40, 0.06, 0.13, 0.00, 0.04, 0.06, 0.39, 0.22, 0.62, 0.00]
-    corr_file: method.txt
-    epsilon: 0.00
-  - name: other
-    shifts: [0.07, 0.12, 0.24, 0.02, 0.10, 0.03, 0.00, 0.00, 0.00, 0.03, 0.00, 0.00, 0.25, 0.09, 0.09, 0.00]
-    corr_file: other.txt
-    epsilon: 0.00
-  - name: NEW
-    shifts: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.50]
-    epsilon: 0.00
+- name: LHCJES1
+  shift:
+    value:
+    - 0.54
+    - 0.33
+    - 0.38
+    - 0.35
+    - 0.28
+    - 0.4
+    - 0.77
+    - 0.24
+    - 0.69
+    - 0.31
+    - 0.1
+    - 0.16
+    - 0.4
+    - 0.0
+    - 0.11
+    - 0.0
+    correlation: LHCJES1.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCJES2
+  shift:
+    value:
+    - 0.3
+    - 0.3
+    - 0.2
+    - 0.41
+    - 0.39
+    - 0.42
+    - 0.54
+    - 0.02
+    - 0.35
+    - 0.17
+    - 0.12
+    - 0.19
+    - 0.21
+    - 0.0
+    - 0.13
+    - 0.0
+    correlation: LHCJES2.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCJES3
+  shift:
+    value:
+    - 0.43
+    - 0.07
+    - 0.24
+    - 0.08
+    - 0.05
+    - 0.12
+    - 0.06
+    - 0.01
+    - 0.08
+    - 0.03
+    - 0.01
+    - 0.02
+    - 0.05
+    - 0.0
+    - 0.01
+    - 0.0
+    correlation: LHCJES3.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCbJES
+  shift:
+    value:
+    - 0.68
+    - 0.06
+    - 0.62
+    - 0.3
+    - 0.03
+    - 0.34
+    - 0.7
+    - 0.61
+    - 0.49
+    - 0.37
+    - 0.32
+    - 0.29
+    - 0.38
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: LHCbJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCgJES
+  shift:
+    value:
+    - 0.03
+    - 0.28
+    - 0.1
+    - 0.02
+    - 0.21
+    - 0.05
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.07
+    - 0.08
+    - 0.02
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: LHCgJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHClJES
+  shift:
+    value:
+    - 0.02
+    - 0.24
+    - 0.02
+    - 0.01
+    - 0.1
+    - 0.06
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.04
+    - 0.06
+    - 0.01
+    - 0.07
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: LHClJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CMSJES
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.58
+    - 0.11
+    - 0.58
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: CMSJES.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: JER
+  shift:
+    value:
+    - 0.19
+    - 0.22
+    - 0.01
+    - 0.09
+    - 0.2
+    - 0.1
+    - 0.14
+    - 0.23
+    - 0.15
+    - 0.0
+    - 0.03
+    - 0.02
+    - 0.05
+    - 0.0
+    - 0.05
+    - 0.0
+    correlation: JER.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: leptons
+  shift:
+    value:
+    - 0.13
+    - 0.04
+    - 0.0
+    - 0.14
+    - 0.16
+    - 0.01
+    - 0.14
+    - 0.02
+    - 0.0
+    - 0.25
+    - 0.01
+    - 0.0
+    - 0.05
+    - 0.1
+    - 0.24
+    - 0.0
+    correlation: leptons.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: btag
+  shift:
+    value:
+    - 0.07
+    - 0.5
+    - 0.16
+    - 0.04
+    - 0.38
+    - 0.1
+    - 0.09
+    - 0.12
+    - 0.06
+    - 0.01
+    - 0.06
+    - 0.02
+    - 0.1
+    - 0.0
+    - 0.02
+    - 0.0
+    correlation: btag.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: ptmiss
+  shift:
+    value:
+    - 0.04
+    - 0.15
+    - 0.02
+    - 0.01
+    - 0.05
+    - 0.01
+    - 0.12
+    - 0.06
+    - 0.0
+    - 0.01
+    - 0.04
+    - 0.0
+    - 0.15
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: ptmiss.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: pileup
+  shift:
+    value:
+    - 0.01
+    - 0.02
+    - 0.02
+    - 0.05
+    - 0.15
+    - 0.01
+    - 0.11
+    - 0.07
+    - 0.06
+    - 0.05
+    - 0.06
+    - 0.06
+    - 0.14
+    - 0.07
+    - 0.05
+    - 0.0
+    correlation: pileup.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: trigger
+  shift:
+    value:
+    - 0.01
+    - 0.0
+    - 0.01
+    - 0.0
+    - 0.01
+    - 0.08
+    - 0.0
+    - 0.0
+    - 0.24
+    - 0.0
+    - 0.0
+    - 0.01
+    - 0.0
+    - 0.02
+    - 0.0
+    - 0.0
+    correlation: trigger.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: ME
+  shift:
+    value:
+    - 0.26
+    - 0.22
+    - 0.3
+    - 0.09
+    - 0.16
+    - 0.18
+    - 0.04
+    - 0.02
+    - 0.19
+    - 0.07
+    - 0.12
+    - 0.16
+    - 0.0
+    - 0.37
+    - 0.42
+    - 0.0
+    correlation: ME.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHCrad
+  shift:
+    value:
+    - 0.47
+    - 0.32
+    - 0.22
+    - 0.23
+    - 0.08
+    - 0.1
+    - 0.58
+    - 0.3
+    - 0.33
+    - 0.24
+    - 0.09
+    - 0.18
+    - 0.35
+    - 0.74
+    - 0.2
+    - 0.0
+    correlation: LHCrad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: LHChad
+  shift:
+    value:
+    - 0.53
+    - 0.18
+    - 0.5
+    - 0.22
+    - 0.15
+    - 0.64
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.38
+    - 0.01
+    - 0.04
+    - 0.0
+    - 0.3
+    - 0.54
+    - 0.0
+    correlation: LHChad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CMSbHad
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.12
+    - 0.16
+    - 0.13
+    - 0.15
+    - 0.0
+    - 0.16
+    - 0.0
+    correlation: CMSbHad.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: CR
+  shift:
+    value:
+    - 0.14
+    - 0.11
+    - 0.22
+    - 0.03
+    - 0.19
+    - 0.12
+    - 0.13
+    - 0.54
+    - 0.15
+    - 0.13
+    - 0.01
+    - 0.16
+    - 0.05
+    - 0.12
+    - 0.08
+    - 0.0
+    correlation: CR.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: UE
+  shift:
+    value:
+    - 0.05
+    - 0.15
+    - 0.08
+    - 0.1
+    - 0.08
+    - 0.12
+    - 0.05
+    - 0.15
+    - 0.2
+    - 0.11
+    - 0.08
+    - 0.14
+    - 0.2
+    - 0.13
+    - 0.0
+    - 0.0
+    correlation: UE.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: PDF
+  shift:
+    value:
+    - 0.1
+    - 0.25
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.09
+    - 0.07
+    - 0.06
+    - 0.17
+    - 0.04
+    - 0.03
+    - 0.11
+    - 0.11
+    - 0.04
+    - 0.0
+    correlation: PDF.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: topPT
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.51
+    - 0.02
+    - 0.06
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    correlation: topPT.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: bkgData
+  shift:
+    value:
+    - 0.04
+    - 0.11
+    - 0.35
+    - 0.07
+    - 0.05
+    - 0.17
+    - 0.0
+    - 0.0
+    - 0.13
+    - 0.0
+    - 0.0
+    - 0.2
+    - 0.0
+    - 0.0
+    - 0.44
+    - 0.0
+    correlation: bkgData.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: bkgMC
+  shift:
+    value:
+    - 0.01
+    - 0.29
+    - 0.0
+    - 0.03
+    - 0.13
+    - 0.0
+    - 0.05
+    - 0.13
+    - 0.0
+    - 0.0
+    - 0.03
+    - 0.0
+    - 0.17
+    - 0.01
+    - 0.0
+    - 0.0
+    correlation: bkgMC.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: method
+  shift:
+    value:
+    - 0.09
+    - 0.11
+    - 0.42
+    - 0.05
+    - 0.13
+    - 0.11
+    - 0.4
+    - 0.06
+    - 0.13
+    - 0.0
+    - 0.04
+    - 0.06
+    - 0.39
+    - 0.22
+    - 0.62
+    - 0.0
+    correlation: method.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: other
+  shift:
+    value:
+    - 0.07
+    - 0.12
+    - 0.24
+    - 0.02
+    - 0.1
+    - 0.03
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.03
+    - 0.0
+    - 0.0
+    - 0.25
+    - 0.09
+    - 0.09
+    - 0.0
+    correlation: other.txt
+  error-on-error:
+    value: 0.0
+    type: dependent
+- name: NEW
+  shift:
+    value:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.5
+    correlation: diagonal
+  error-on-error:
+    value: 0.0
+    type: dependent

--- a/tutorials/top-mass/test_run.py
+++ b/tutorials/top-mass/test_run.py
@@ -1,0 +1,15 @@
+import sys, os
+base = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, base)
+from gvm_toolkit import GVMCombination
+
+here = os.path.dirname(__file__)
+os.chdir(here)
+comb = GVMCombination('input_files/LHC_comb.yaml')
+info = comb.input_data()
+for k in info['syst']:
+    info['syst'][k]['error-on-error']['value'] = 0.0
+info['syst']['LHCbJES']['error-on-error']['value'] = 0.1
+comb.update_data(info)
+print('mu', comb.fit_results['mu'])
+print('ci', comb.confidence_interval())

--- a/tutorials/top-mass/top-mass-combination.ipynb
+++ b/tutorials/top-mass/top-mass-combination.ipynb
@@ -62,8 +62,7 @@
    "source": [
     "comb           = GVMCombination('input_files/LHC_comb.yaml')\n",
     "mu_hat         = comb.fit_results['mu']\n",
-    "ci_low, ci_high, _ = comb.confidence_interval()\n",
-    "ci_half        = (ci_high - ci_low) / 2\n",
+    "ci_low, ci_high, ci_half = comb.confidence_interval()\n",
     "chi2           = comb.goodness_of_fit()\n",
     "ndof           = comb.n_meas - 1\n",
     "\n",
@@ -113,9 +112,9 @@
     "for syst in systematics:\n",
     "    info = comb.input_data()\n",
     "    for k in info['syst']:\n",
-    "        info['syst'][k]['epsilon'] = 0.0\n",
+    "        info['syst'][k]['error-on-error']['value'] = 0.0\n",
     "    for eps in eps_grid:\n",
-    "        info['syst'][syst]['epsilon'] = eps\n",
+    "        info['syst'][syst]['error-on-error']['value'] = eps\n",
     "        comb.update_data(info)\n",
     "        cv[syst].append(comb.fit_results['mu'])\n",
     "        ci[syst].append(comb.confidence_interval()[2])"


### PR DESCRIPTION
## Summary
- migrate top-mass YAML configs to new `shift`/`error-on-error` schema
- adapt notebook to new API for error-on-error handling

## Testing
- `python -m py_compile gvm_toolkit.py`
- `python tutorials/top-mass/test_run.py` *(run combination and confidence interval)*

------
https://chatgpt.com/codex/tasks/task_e_68a091327a00832c96e32a2698bdca55